### PR TITLE
[ReactPoll] Major update

### DIFF
--- a/reactpoll/converters.py
+++ b/reactpoll/converters.py
@@ -1,0 +1,87 @@
+import logging
+import re
+from typing import List, Union, Dict
+from datetime import timedelta
+
+from discord.ext.commands.converter import Converter
+from discord.ext.commands.errors import BadArgument
+from redbot.core import commands
+
+log = logging.getLogger("red.flapjackcogs.reactpoll")
+
+# the following regex is slightly modified from Red
+# https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/core/commands/converter.py#L55
+TIME_RE_STRING = r"|".join(
+    [
+        r"((?P<weeks>\d+?)\s?(weeks?|w))",
+        r"((?P<days>\d+?)\s?(days?|d))",
+        r"((?P<hours>\d+?)\s?(hours?|hrs|hr?))",
+        r"((?P<minutes>\d+?)\s?(minutes?|mins?|m(?!o)))",  # prevent matching "months"
+        r"((?P<seconds>\d+?)\s?(seconds?|secs?|s))",
+    ]
+)
+TIME_RE = re.compile(TIME_RE_STRING, re.I)
+QUESTION_RE = re.compile(r"([^;]+)(?<=\?)\s?", re.I)
+OPTIONS_RE = re.compile(r"([\S]+)(?=;)[\S\s]+", re.I)
+SPLIT_RE = re.compile(r";")
+TIME_SPLIT = re.compile(r"t(?:ime)?=")
+MULTI_RE = re.compile(r"(multi(?:ple)?[\W\_]votes?)", re.I)
+
+
+class PollOptions(Converter):
+    """
+    This will parse my defined multi response pattern and provide usable formats
+    to be used in multiple reponses
+    """
+
+    async def convert(
+        self, ctx: commands.Context, argument: str
+    ) -> Dict[str, Union[List[str], str, bool, timedelta]]:
+        result: Dict[str, Union[List[str], str, bool, timedelta]] = {}
+        if MULTI_RE.findall(argument):
+            result["multiple_votes"] = True
+            argument = MULTI_RE.sub("", argument)
+        result, argument = self.strip_question(result, argument)
+        # log.info(argument)
+        result, argument = self.strip_time(result, argument)
+        # log.info(argument)
+        result, argument = self.strip_options(result, argument)
+        # log.info(argument)
+        result["author_id"] = ctx.author.id
+        return result
+
+    def strip_question(self, result: Dict[str, Union[List[str], str, bool, timedelta]], argument: str):
+        match = QUESTION_RE.match(argument)
+        if not match:
+            raise BadArgument("That doesn't look like a question.")
+        result["question"] = match[0]
+        no_question = QUESTION_RE.sub("", argument)
+        return result, no_question
+
+    def strip_options(self, result: Dict[str, Union[List[str], str, bool, timedelta]], argument: str):
+        possible_options = OPTIONS_RE.match(argument)
+        if not possible_options:
+            raise BadArgument("You have no options for this poll.")
+        options = [s.strip() for s in SPLIT_RE.split(possible_options[0]) if s]
+        if len(options) > 20:
+            raise BadArgument("Use less options for the poll. Max options: 20.")
+        result["options"] = options
+        no_options = OPTIONS_RE.sub("", argument)
+        return result, no_options
+
+    def strip_time(self, result: Dict[str, Union[List[str], str, bool, timedelta]], argument: str):
+        time_split = TIME_SPLIT.split(argument)
+        if time_split:
+            maybe_time = time_split[-1]
+        else:
+            maybe_time = argument
+
+        time_data = {}
+        for time in TIME_RE.finditer(maybe_time):
+            argument = argument.replace(time[0], "")
+            for k, v in time.groupdict().items():
+                if v:
+                    time_data[k] = int(v)
+        if time_data:
+            result["duration"] = timedelta(**time_data)
+        return result, argument

--- a/reactpoll/converters.py
+++ b/reactpoll/converters.py
@@ -25,7 +25,7 @@ QUESTION_RE = re.compile(r"([^;]+)(?<=\?)\s?", re.I)
 OPTIONS_RE = re.compile(r"([\S]+)(?=;)[\S\s]+", re.I)
 SPLIT_RE = re.compile(r";")
 TIME_SPLIT = re.compile(r"t(?:ime)?=")
-MULTI_RE = re.compile(r"(multi(?:ple)?[\W\_]votes?)", re.I)
+MULTI_RE = re.compile(r"(multi-vote)", re.I)
 
 
 class PollOptions(Converter):

--- a/reactpoll/polls.py
+++ b/reactpoll/polls.py
@@ -165,8 +165,7 @@ class Poll:
         if self.duration:
             end = "| ends at"
         em.set_footer(
-            text=f"{self.author} created a poll {end}",
-            icon_url=str(self.author.avatar_url),
+            text=f"{self.author} created a poll {end}", icon_url=str(self.author.avatar_url),
         )
         if self.end_time:
             em.timestamp = self.end_time
@@ -184,13 +183,16 @@ class Poll:
         start_adding_reactions(message, self.emojis.keys())
 
     async def close_poll(self):
+
         msg = "**POLL ENDED!**\n\n"
         try:
             old_msg = await self.get_message()
             if old_msg:
                 await old_msg.clear_reactions()
         except (discord.errors.Forbidden, discord.errors.NotFound):
+            log.error("Cannot find message")
             pass
+
         em = discord.Embed(colour=await self.bot.get_embed_colour(self.channel))
         em.title = "**POLL ENDED**"
         # This is handled with fuck-all efficiency, but it works for now -Ruined1

--- a/reactpoll/polls.py
+++ b/reactpoll/polls.py
@@ -1,0 +1,225 @@
+import asyncio
+import discord
+import random
+import string
+import logging
+
+from typing import Dict, Optional, List
+from datetime import datetime, timedelta
+
+from redbot.core.bot import Red
+from redbot.core.utils.chat_formatting import humanize_timedelta, pagify
+from redbot.core.utils.menus import start_adding_reactions
+from redbot.core.utils.predicates import ReactionPredicate
+
+log = logging.getLogger("red.flapjackcogs.reactpoll")
+
+
+class Poll:
+    """A new reaction poll"""
+
+    def __init__(self, bot, **kwargs):
+        self.duration: Optional[timedelta] = kwargs.get("duration")
+        self.tally: Dict[str, List[int]] = kwargs.get("tally", {})
+        # Thanks 26 remindme.py
+        # Following are needed to reconstruct a poll
+        self.author_id: int = kwargs.get("author_id")
+        self.channel_id: int = kwargs.get("channel_id")
+        self.message_id: Optional[int] = kwargs.get("message_id", None)
+        self.question: str = kwargs.get("question")
+        self.emojis: Dict[str, str] = kwargs.get("emojis", {})
+        self.options: List[str] = kwargs.get("options")
+        self.end_time: Optional[datetime] = kwargs.get(
+            "end_time", self.parse_duration(self.duration)
+        )
+        self.embed: bool = kwargs.get("embed", True)
+        self.interactive: bool = kwargs.get("interactive", False)
+        self.multiple_votes: bool = kwargs.get("multiple_votes", False)
+        self._bot: Red = bot
+
+    def as_dict(self):
+        # for JSON serialization. This dict completely defines a poll.
+        return {
+            "author_id": self.author_id,
+            "channel_id": self.channel_id,
+            "message_id": self.message_id,
+            "question": self.question,
+            "options": self.options,
+            "emoji": self.emojis,
+            "end_time": self.end_time.timestamp() if self.end_time else None,
+            "tally": self.tally,
+            "embed": self.embed,
+        }
+
+    def parse_duration(self, duration: Optional[timedelta] = None) -> Optional[datetime]:
+        # use remindme parsing for now
+        if duration:
+            return datetime.utcnow() + duration
+        else:
+            return None
+
+    async def add_vote(self, user_id: int, emoji: str):
+        # log.info("Adding vote")
+        member = self.channel.guild.get_member(int(user_id))
+        if emoji not in self.emojis:
+            # attempt to remove emoji and DM use not to clutter the poll
+            if self.channel.permissions_for(self.guild.me).manage_messages:
+                old_msg = await self.get_message()
+                try:
+                    await old_msg.remove_reaction(emoji, member)
+                except Exception:
+                    pass
+            if member:
+                try:
+                    await member.send("Don't clutter the poll.")
+                except discord.errors.Forbidden:
+                    pass
+            return
+        if not self.multiple_votes:
+            for e in self.tally:
+                if user_id in self.tally[e] and emoji != e:
+                    # DM user telling them their vote has changed
+                    if self.channel.permissions_for(self.guild.me).manage_messages:
+                        old_msg = await self.get_message()
+                        self.tally[e].remove(user_id)
+                        try:
+                            await old_msg.remove_reaction(e, member)
+                        except Exception:
+                            pass
+                    if member:
+                        try:
+                            await member.send(
+                                f"You've already voted on `{self.question}`, changing vote to {emoji}."
+                            )
+                        except discord.errors.Forbidden:
+                            pass
+            if user_id not in self.tally[emoji]:
+                self.tally[emoji].append(user_id)
+
+        else:
+            if user_id not in self.tally[emoji]:
+                self.tally[emoji].append(user_id)
+
+    async def remove_vote(self, user_id: int, emoji: str):
+        if user_id in self.tally[emoji]:
+            self.tally[emoji].remove(user_id)
+
+    @property
+    def bot(self):
+        return self._bot
+
+    @property
+    def channel(self):
+        return self.bot.get_channel(self.channel_id)
+
+    @property
+    def guild(self):
+        return self.channel.guild
+
+    @property
+    def author(self):
+        return self.guild.get_member(self.author_id)
+
+    async def get_message(self):
+        channel = self.channel
+        if not channel:
+            return None
+        try:
+            message = await channel.fetch_message(self.message_id)
+        except discord.errors.HTTPException:
+            return None
+        return message
+
+    async def build_poll(self):
+        # Starting codepoint for keycap number emoji (\u0030... == 0)
+        base_emoji = ReactionPredicate.NUMBER_EMOJIS + ReactionPredicate.ALPHABET_EMOJIS
+        msg = "**POLL STARTED!**\n\n{}\n\n".format(self.question)
+        option_num = 1
+        option_msg = ""
+        if not self.interactive:
+            for option in self.options:
+                emoji = base_emoji[option_num]
+                self.emojis[emoji] = option
+                option_msg += f"**{option_num}**. {option}\n"
+                option_num += 1
+        else:
+            for emoji, option in self.emojis.items():
+                option_msg += f"{emoji}. {option}\n"
+        if not self.tally:
+            self.tally = {e: [] for e in self.emojis}
+        msg += option_msg
+        msg += "\nSelect the number to vote!"
+        if self.duration:
+            msg += f"\nPoll closes in {humanize_timedelta(timedelta=self.duration)}"
+
+        em = discord.Embed(colour=await self.bot.get_embed_colour(self.channel))
+        em.title = "POLL STARTED!"
+        first = True
+        for page in pagify(f"{self.question}\n\n{option_msg}", page_length=1024):
+            if first:
+                em.description = page
+                first = False
+            else:
+                em.add_field(name="Options continued", value=page)
+        end = ""
+        if self.duration:
+            end = "| ends at"
+        em.set_footer(
+            text=f"{self.author} created a poll {end}",
+            icon_url=str(self.author.avatar_url),
+        )
+        if self.end_time:
+            em.timestamp = self.end_time
+        return msg, em
+
+    async def open_poll(self):
+        msg, em = await self.build_poll()
+        if not self.embed:
+            for page in pagify(msg):
+                message = await self.channel.send(page)
+        else:
+            message = await self.channel.send(embed=em)
+        self.message_id = message.id
+        self.end_time = self.parse_duration(self.duration)
+        start_adding_reactions(message, self.emojis.keys())
+
+    async def close_poll(self):
+        msg = "**POLL ENDED!**\n\n"
+        try:
+            old_msg = await self.get_message()
+            if old_msg:
+                await old_msg.clear_reactions()
+        except (discord.errors.Forbidden, discord.errors.NotFound):
+            pass
+        em = discord.Embed(colour=await self.bot.get_embed_colour(self.channel))
+        em.title = "**POLL ENDED**"
+        # This is handled with fuck-all efficiency, but it works for now -Ruined1
+        if sum(len(v) for k, v in self.tally.items()) == 0:
+            msg += "***NO ONE VOTED.***\n"
+            try:
+                if self.embed:
+                    await self.channel.send(msg)
+                else:
+                    em.description = f"{self.question}\n\n***NO ONE VOTED.***\n"
+                    await self.channel.send(embed=em)
+            except (discord.errors.Forbidden, discord.errors.NotFound, AttributeError):
+                pass
+        votes_msg = f"{self.question}\n\n**Results**\n"
+        for e, vote in sorted(self.tally.items(), key=lambda x: len(x[1]), reverse=True):
+            votes_msg += f"{self.emojis[e]}: {len(vote)}\n"
+        msg += votes_msg
+        first = True
+        for page in pagify(votes_msg, page_length=1024):
+            if first:
+                em.description = page
+                first = False
+            else:
+                em.add_field(name="Results continued", value=page)
+        try:
+            if not self.embed:
+                for page in pagify(msg):
+                    await self.channel.send(page)
+            else:
+                await self.channel.send(embed=em)
+        except (discord.errors.Forbidden, discord.errors.NotFound, AttributeError):
+            pass

--- a/reactpoll/reactpoll.py
+++ b/reactpoll/reactpoll.py
@@ -351,9 +351,11 @@ class ReactPoll(commands.Cog):
             The options are a list separated by `;`.
             The time the poll ends is a space separated list of units of time.
             Usage example (time argument is optional)
-            if `multiple votes` is provided anywhere in the creation message the poll
+            if `multi-vote` is provided anywhere in the creation message the poll
             will allow users to vote on multiple choices.
-            [p]rpoll new Is this a poll? Yes;No;Maybe; 2 hours 21 minutes 40 seconds
+
+            Example format:
+            `[p]rpoll new Is this a poll? Yes;No;Maybe; 2 hours 21 minutes 40 seconds multi-vote`
         """
         if not channel:
             send_channel = ctx.channel


### PR DESCRIPTION
This PR adds a new parsing mechanism for reaction polls. It will attempt to simulate v2 style reaction poll creation through the `[p]rpoll new` command.

This will also add the option of having embeds for reaction polls. By default polls will use embeds but they can be explicitly toggled off by a mod per server.

There is a new interactive poll creator to allow for up to 20 options (limited by reactions) and multiple pages for massive polls.

Reactions are tracked via raw_reaction_add/remove now and saved every ~60 seconds via the close loop.

By default reaction polls will now prevent multiple votes although this can be toggled by providing `multiple votes` inside either poll creation setup method.

This will also solve #105 and #69 