### PR TITLE
Added information about output with every wordcloud result

### DIFF
--- a/wordclouds/wordclouds.py
+++ b/wordclouds/wordclouds.py
@@ -186,7 +186,11 @@ class WordClouds(commands.Cog):
         except asyncio.TimeoutError:
             await ctx.send("Wordcloud creation timed out.")
             return
-        await ctx.send(file=discord.File(image))
+        msg = "Wordcloud for **" + guild.name + "/" + channel.name
+        if user is not None:
+            msg += "/" + user.display_name
+        msg += "** using the last {} messages.".format(limit)
+        await ctx.send(msg,file=discord.File(image))
 
     @staticmethod
     def generate(text, **kwargs):


### PR DESCRIPTION
It will add a text line that says what the wordcloud is about with every output wordcloud. I did this on my end to clear up confusions when generating a lot of wordclouds, and it worked flawlessly. 