### PR TITLE
[ReactPoll] Anonymous voting, embed color support, and more

### DIFF
--- a/reactpoll/converters.py
+++ b/reactpoll/converters.py
@@ -26,7 +26,8 @@ OPTIONS_RE = re.compile(r"([\S\s]+)(?=;)[\S\s]+", re.I)
 SPLIT_RE = re.compile(r";")
 TIME_SPLIT = re.compile(r"t(?:ime)?=")
 MULTI_RE = re.compile(r"(multi-vote)", re.I)
-
+ANONYMOUS_RE = re.compile(r"(anonymous)", re.I)
+COLOUR_RE = re.compile(r"(#(?:[0-9a-fA-F]{3}){1,2})", re.I)
 
 class PollOptions(Converter):
     """
@@ -41,6 +42,16 @@ class PollOptions(Converter):
         if MULTI_RE.findall(argument):
             result["multiple_votes"] = True
             argument = MULTI_RE.sub("", argument)
+
+        if ANONYMOUS_RE.findall(argument):
+            result["anonymous"] = True
+            argument = ANONYMOUS_RE.sub("", argument)
+
+        COLOUR = COLOUR_RE.findall(argument)
+        if COLOUR:
+            result["colour"] = self.hex_to_rgb(COLOUR[0])
+            argument = COLOUR_RE.sub("", argument)
+
         result, argument = self.strip_question(result, argument)
         # log.info(argument)
         result, argument = self.strip_time(result, argument)
@@ -85,3 +96,8 @@ class PollOptions(Converter):
         if time_data:
             result["duration"] = timedelta(**time_data)
         return result, argument
+
+    def hex_to_rgb(self, color):
+        if len(color) <= 4:
+            return tuple(int(color[i]*2, 16) for i in (1, 2, 3))
+        return tuple(int(color[i:i+2], 16) for i in (1, 3, 5))


### PR DESCRIPTION
The vast majority of polling bots have the choice to make a poll anonymous (i.e., reactions are removed) to prevent herding or to make votes/polls more "honest". Now this cog does as well, with the option `anonymous` (which is declared the same way as the multi-vote method, and works alongside it.) The user will receive a DM that their vote has been recorded, similarly to if they'd changed their vote. Until Red gets button support and by extension ephemeral messages, this should do fine. I think.

I've also added the ability to choose the embed color by providing a 3 or 6 character hex code prefixed with `#`. If no hex code is provided, the will use either `channel.guild.me.colour`, or `self.bot.db.color()` (which was the default before)

I started writing up preliminary support for choosing custom emojis in the `rpoll new` method, which would allow custom emojis without going through the interactive menu. It works fine for custom Discord emojis, provided the bot can access them, but it doesn't yet work with the default emojis, as they are converted into Unicode for some reason and therefore they don't satisfy the current regex search method used in the cog, `EMOJI_RE = re.compile(r"<a?:[a-zA-Z0-9\_]+:([0-9]+)>")`. If anyone has any ideas how to extract the emojis, that'd be greatly appreciated! :)

Other than that, I've tested it pretty thoroughly will all combinations of new + old options, including without the embeds and on multiple accounts. Should be all set to merge.