### PR TITLE
[ReactPoll] Fixed unintended behavior in rpollset embed

### DIFF
--- a/reactpoll/polls.py
+++ b/reactpoll/polls.py
@@ -220,16 +220,9 @@ class Poll:
         em.title = "**POLL ENDED**"
         # This is handled with fuck-all efficiency, but it works for now -Ruined1
         if sum(len(v) for k, v in self.tally.items()) == 0:
-            msg += "***NO ONE VOTED.***\n"
-            try:
-                if self.embed:
-                    await self.channel.send(msg)
-                else:
-                    em.description = f"{self.question}\n\n***NO ONE VOTED.***\n"
-                    await self.channel.send(embed=em)
-            except (discord.errors.Forbidden, discord.errors.NotFound, AttributeError):
-                pass
-        votes_msg = f"{self.question}\n\n**Results**\n"
+            votes_msg = f"{self.question}\n\n***NO ONE VOTED.***\n\n**Results**\n"
+        else:
+            votes_msg = f"{self.question}\n\n**Results**\n"
         for e, vote in sorted(self.tally.items(), key=lambda x: len(x[1]), reverse=True):
             votes_msg += f"{self.emojis[e]}: {len(vote)}\n"
         msg += votes_msg


### PR DESCRIPTION
In the current branch, `.rpollset embed` doesn't behave correctly when no votes are received -- it also sends in two separate messages with the question and **_NO ONE VOTED_** message: one that obeys the current `rpollset embed` setting, and one that doesn't. (see below for examples.)

To rectify this, the code block responsible has been greatly simplified, and sending the message happens in one place at the end of the method instead of at the middle _and_ at the end. I'm welcome to suggestions for formatting changes, but the logic itself should be sound.

**CURRENT BRANCH BEHAVIOR:**
- **Ending a poll in current branch with no votes (`rpollset embed` on):**
![image](https://user-images.githubusercontent.com/21323030/150546674-c9ac8e8b-1032-44ba-8c6f-3d071f882f02.png)

- **Ending a poll in current branch with no votes (`rpollset embed` off):**
![image](https://user-images.githubusercontent.com/21323030/150547011-32c1e527-516e-4a83-ad14-0439f85cd423.png)

**PR BRANCH BEHAVIOR:**
- **Ending a poll in PR branch with no votes (`rpollset embed` on):**
![image](https://user-images.githubusercontent.com/21323030/150547790-7262b793-29a0-44cc-adde-8a133a42965e.png)

- **Ending a poll in PR branch with no votes (`rpollset embed` off):**
![image](https://user-images.githubusercontent.com/21323030/150547700-7b80b63e-09f8-4ab1-a16f-e732d16c43cb.png)

