### PR TITLE
[ReactPoll] Always list emoji rather than indices

### DIFF
--- a/reactpoll/polls.py
+++ b/reactpoll/polls.py
@@ -152,7 +152,7 @@ class Poll:
             for option in self.options:
                 emoji = base_emoji[option_num]
                 self.emojis[emoji] = option
-                option_msg += f"**{option_num}**. {option}\n"
+                option_msg += f"{emoji}. {option}\n"
                 option_num += 1
         else:
             for emoji, option in self.emojis.items():


### PR DESCRIPTION
ReactPoll uses the option index rather than the related reaction to list the poll options, which led to
[some confusion](https://user-images.githubusercontent.com/23347632/151073845-af8fa169-b302-49a7-bd3e-92c1075ae6d0.png) in a server I admin for.

[Here is a picture](https://user-images.githubusercontent.com/23347632/151073953-b18a3796-f0b1-4940-bb17-86fdfb7901a8.png) of the same poll with these changes implemented.
