### PR TITLE
[smartreact] Use `TypeError` in place of `discord.errors.InvalidArgument`

### DIFF
--- a/smartreact/smartreact.py
+++ b/smartreact/smartreact.py
@@ -140,7 +140,7 @@ class SmartReact(commands.Cog):
             await self.conf.guild(guild).reactions.set(reactions)
             await message.channel.send("Successfully added this reaction.")
 
-        except (discord.errors.HTTPException):
+        except (discord.errors.HTTPException, TypeError):
             await message.channel.send("That's not an emoji I recognize. (might be custom!)")
 
     async def remove_smart_reaction(self, guild, word, emoji, message):
@@ -158,7 +158,7 @@ class SmartReact(commands.Cog):
                     await message.channel.send("That emoji is not used as a reaction for that word.")
             else:
                 await message.channel.send("There are no smart reactions which use this emoji.")
-        except (discord.errors.HTTPException):
+        except (discord.errors.HTTPException, TypeError):
             await message.channel.send("That's not an emoji I recognize. (might be custom!)")
 
     # Thanks irdumb#1229 for the help making this "more Pythonic"
@@ -181,7 +181,7 @@ class SmartReact(commands.Cog):
                     return
                 try:
                     await message.add_reaction(emoji)
-                except (discord.errors.Forbidden, discord.errors.InvalidArgument, discord.errors.NotFound):
+                except (discord.errors.Forbidden, TypeError, discord.errors.NotFound):
                     pass
                 except discord.errors.HTTPException:
                     if emoji in reacts:


### PR DESCRIPTION
```py
Exception in command 'addreact'
Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/.local/share/Red-DiscordBot/data/dusky/cogs/CogManager/cogs/smartreact/smartreact.py", line 41, in addreact
    await self.create_smart_reaction(ctx.guild, word, emoji, ctx.message)
  File "/home/ubuntu/.local/share/Red-DiscordBot/data/dusky/cogs/CogManager/cogs/smartreact/smartreact.py", line 130, in create_smart_reaction
    await message.add_reaction(emoji)
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/message.py", line 1115, in add_reaction
    emoji = convert_emoji_reaction(emoji)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/message.py", line 128, in convert_emoji_reaction
    raise TypeError(f'emoji argument must be str, Emoji, or Reaction not {emoji.__class__.__name__}.')
TypeError: emoji argument must be str, Emoji, or Reaction not NoneType.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/bot.py", line 1350, in invoke
    await ctx.command.invoke(ctx)
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 1029, in invoke
    await injected(*ctx.args, **ctx.kwargs)  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/redenv/lib/python3.11/site-packages/discord/ext/commands/core.py", line 244, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: TypeError: emoji argument must be str, Emoji, or Reaction not NoneType.
```